### PR TITLE
Fix when attribute is missing from value in signal handler

### DIFF
--- a/rdmo_orcid/handlers.py
+++ b/rdmo_orcid/handlers.py
@@ -20,8 +20,8 @@ def orcid_handler(signal, sender, instance=None, **kwargs):
     if kwargs.get('raw'):
         return
 
-    # check if this value instance has an external_id
-    if not instance.external_id:
+    # check if this value instance has an external_id or has an attribute (it may have been deleted)
+    if not instance.external_id or instance.attribute_id is None:
         return
 
     # loop over ORCID_PROVIDER_MAP and check if the value instance attribute is found

--- a/rdmo_orcid/handlers.py
+++ b/rdmo_orcid/handlers.py
@@ -21,7 +21,7 @@ def orcid_handler(signal, sender, instance=None, **kwargs):
         return
 
     # check if this value instance has an external_id or has an attribute (it may have been deleted)
-    if not instance.external_id or instance.attribute_id is None:
+    if not instance.external_id or not instance.attribute_id:
         return
 
     # loop over ORCID_PROVIDER_MAP and check if the value instance attribute is found


### PR DESCRIPTION
We get some errors because of `'NoneType' object has no attribute 'uri' ` in `rdmo_orcid/handlers.py`:

```shell
AttributeError at /api/v1/projects/projects/123/values/456/ 
'NoneType' object has no attribute 'uri' 
Request Method: PUT Request URL: https://example.com/api/v1/projects/projects/123/values/456/
Django Version: 5.2.16
Exception Type: AttributeError 
Exception Value: 'NoneType' object has no attribute 'uri' 
Exception Location: /srv/rdmo/rdmo-plugins/rdmo-plugins-orcid/rdmo_orcid/handlers.py, line 113, in orcid_handler_func 
Raised during: rdmo.projects.viewsets.ProjectValueViewSet
```